### PR TITLE
Remove license line in readme

### DIFF
--- a/intro-end-to-end/README.md
+++ b/intro-end-to-end/README.md
@@ -53,7 +53,3 @@ For comprehensive platform documentation, visit [docs.contextual.ai](https://doc
 ## Support
 
 For additional support or questions, please refer to the official documentation or contact the Contextual AI support team.
-
-## License
-
-[Include your license information here]


### PR DESCRIPTION
Removing the license information, it's redundant and already on the main readme