### PR TITLE
added code for filter prompt and getting metrics

### DIFF
--- a/01-getting-started/end-to-end-example.ipynb
+++ b/01-getting-started/end-to-end-example.ipynb
@@ -821,7 +821,7 @@
    "source": [
     "#### 6.2.3 Checking the status.\n",
     "\n",
-    " You can check the status of the job using the API. For detailed information, refer to the API documentation\". When the tuning job is complete, the status will turn to completed. The response payload will also contain evaluation_results, such as scores for equivalence, helpfulness, and groundedness."
+    " You can check the status of the job using the API. For detailed information, refer to the API documentation\". When the tuning job is complete, the status will turn to completed. The response payload will also contain evaluation_results, such as scores for equivalence."
    ]
   },
   {
@@ -851,11 +851,19 @@
    "source": [
     "When the tuning job is complete, the metadata would look like the following:\n",
     "```\n",
-    "{'job_status': 'completed',\n",
-    " 'evaluation_results': {'grounded_generation_train_test.json_equivalence': 1.0,\n",
-    "  'grounded_generation_train_test.json_helpfulness': 0.814156498263641,\n",
-    "  'grounded_generation_train_test.json_groundedness': 0.7781168677598632},\n",
-    " 'model_id': 'registry/model-ada3c484-3ce0f31f-llm-fd6c2'}\n",
+    "TuneJobMetadata(job_status='completed',\n",
+    "                evaluation_results=None,\n",
+    "                model_id='registry/tuned-model-101',\n",
+    "                id='e44661f0-bagb-4919-b0df-bada36a31',\n",
+    "                evaluation_metadata={'status': 'completed',\n",
+    "                                     'metrics': {'equivalence_score': {'score': 0.873}},\n",
+    "                                     'job_metadata': {'num_predictions': 200,\n",
+    "                                                      'num_failed_predictions': 0,\n",
+    "                                                      'num_successful_predictions': 200,\n",
+    "                                                      'num_processed_predictions': 0},\n",
+    "                                     'dataset_name': 'eval-results-101',\n",
+    "                                     'model_name': 'registry/tuned-model-101',\n",
+    "                                     'tune_job_id': 'e44661f0-bagb-4919-b0df-bada36a31'})\n",
     " ```"
    ]
   },

--- a/02-hands-on-lab/lab3_improve_agent.ipynb
+++ b/02-hands-on-lab/lab3_improve_agent.ipynb
@@ -375,7 +375,7 @@
    "source": [
     "#### 6.2.3 Checking the status.\n",
     "\n",
-    " You can check the status of the job using the API. For detailed information, refer to the API documentation\". When the tuning job is complete, the status will turn to completed. The response payload will also contain evaluation_results, such as scores for equivalence, helpfulness, and groundedness."
+    " You can check the status of the job using the API. For detailed information, refer to the API documentation\". When the tuning job is complete, the status will turn to completed. The response payload will also contain evaluation_results, such as scores for equivalence."
    ]
   },
   {
@@ -413,11 +413,19 @@
    "source": [
     "When the tuning job is complete, the metadata would look like the following:\n",
     "```\n",
-    "{'job_status': 'completed',\n",
-    " 'evaluation_results': {'grounded_generation_train_test.json_equivalence': 1.0,\n",
-    "  'grounded_generation_train_test.json_helpfulness': 0.814156498263641,\n",
-    "  'grounded_generation_train_test.json_groundedness': 0.7781168677598632},\n",
-    " 'model_id': 'registry/model-ada3c484-3ce0f31f-llm-fd6c2'}\n",
+    "TuneJobMetadata(job_status='completed',\n",
+    "                evaluation_results=None,\n",
+    "                model_id='registry/tuned-model-101',\n",
+    "                id='e44661f0-bagb-4919-b0df-bada36a31',\n",
+    "                evaluation_metadata={'status': 'completed',\n",
+    "                                     'metrics': {'equivalence_score': {'score': 0.873}},\n",
+    "                                     'job_metadata': {'num_predictions': 200,\n",
+    "                                                      'num_failed_predictions': 0,\n",
+    "                                                      'num_successful_predictions': 200,\n",
+    "                                                      'num_processed_predictions': 0},\n",
+    "                                     'dataset_name': 'eval-results-101',\n",
+    "                                     'model_name': 'registry/tuned-model-101',\n",
+    "                                     'tune_job_id': 'e44661f0-bagb-4919-b0df-bada36a31'})\n",
     " ```"
    ]
   },

--- a/06-improve-agent-performance/improvement-overview.ipynb
+++ b/06-improve-agent-performance/improvement-overview.ipynb
@@ -19,8 +19,12 @@
         "- Evaluation Job\n",
         "- Modifying System Prompt\n",
         "- Retrieval Settings\n",
+        "- Filter Model / Prompt\n",
         "- Generation Settings\n",
         "- Tuning the Agent\n",
+        "\n",
+        "For getting usage data and agent feedback, check out example using the metrics API in the [quick start notebook](https://github.com/ContextualAI/examples/tree/main/01-getting-started/quick-start.ipynb).\n",
+        "\n",
         "\n",
         "The notebook requires you to first build an agent going through the [getting started](https://github.com/ContextualAI/examples/tree/main/01-getting-started) or the [hands on lab](https://github.com/ContextualAI/examples/tree/main/02-hands-on-lab).\n",
         "\n",
@@ -31,7 +35,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 11,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -56,7 +60,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 12,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -76,7 +80,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 13,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -84,7 +88,16 @@
         "id": "hUk8u_lSOArL",
         "outputId": "a79c80a1-5772-4078-e32b-b58119fd32dd"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Fetching data/eval_short.csv\n",
+            "Fetching data/fin_train.jsonl\n"
+          ]
+        }
+      ],
       "source": [
         "def fetch_file(filepath):\n",
         "    if not os.path.exists(os.path.dirname(filepath)):  # Ensure the directory exists\n",
@@ -124,13 +137,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 4,
       "metadata": {
         "id": "WvlwoXzSQP1w"
       },
       "outputs": [],
       "source": [
-        "agent_id = 'add_your_agent_id_here'"
+        "agent_id = 'eea5bd52-e207-4761-98ff-e2f6536eb5ee'"
       ]
     },
     {
@@ -144,7 +157,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 14,
       "metadata": {
         "id": "Bvc2MkpDQP1x"
       },
@@ -170,9 +183,26 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 15,
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Apple's total net sales for the quarter ended December 31, 2022 were $117.2 billion, representing a 5% decrease from $123.9 billion in the same quarter of 2021.[2]()[3]() This decline was primarily attributed to foreign currency weakness against the U.S. dollar.[1]()\n",
+            "\n",
+            "Product Segment Performance:\n",
+            "- iPhone: $65.8 billion (down 8% year-over-year)[2]()[3]()\n",
+            "- Mac: $7.7 billion (down 29% year-over-year)[2]()[3]()\n",
+            "- iPad: $9.4 billion (up 30% year-over-year)[2]()[3]()\n",
+            "- Wearables, Home and Accessories: $13.5 billion (down 8% year-over-year)[2]()[3]()\n",
+            "- Services: $20.8 billion (up 6% year-over-year)[2]()[3]()\n",
+            "\n",
+            "The iPhone sales decrease was primarily due to lower sales of new iPhone models launched in the fourth quarter of 2022.[4]() The Mac segment decline was mainly driven by decreased MacBook Pro sales.[5]()\n"
+          ]
+        }
+      ],
       "source": [
         "content = query_result.message.content\n",
         "print(content)"
@@ -189,14 +219,33 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 18,
       "metadata": {
         "id": "aR-rCnf5QP1x"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Section: FORM 10-Q\n",
+            "Sub-Section: iPhone\n",
+            "\n",
+            "\n",
+            "iPhone net sales decreased during the first quarter of 2023 compared to the same quarter in 2022 due primarily to lower net sales from the Company’s new iPhone models launched in the fourth quarter of 2022.\n"
+          ]
+        }
+      ],
       "source": [
-        "context_text = query_result.retrieval_contents[0].content_text\n",
+        "context_text = query_result.retrieval_contents[3].content_text\n",
         "print(context_text)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "For getting usage data and agent feedback, check out example using the metrics API in the [quick start notebook](https://github.com/ContextualAI/examples/tree/main/01-getting-started/quick-start.ipynb).\n"
       ]
     },
     {
@@ -208,7 +257,7 @@
         "## 2: Running Evaluation Jobs\n",
         "\n",
         "Contextual AI offer two different endpoints for running evaluation jobs.\n",
-        "  - Evaluation assessing ground truth\n",
+        "  - Evaluation based on ground truth examples\n",
         "  - Natural language unit tests (LMUnit)\n",
         "\n"
       ]
@@ -239,11 +288,139 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 19,
       "metadata": {
         "id": "zeue_glVQP1y"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+              "columns": [
+                {
+                  "name": "index",
+                  "rawType": "int64",
+                  "type": "integer"
+                },
+                {
+                  "name": "prompt",
+                  "rawType": "object",
+                  "type": "string"
+                },
+                {
+                  "name": "reference",
+                  "rawType": "object",
+                  "type": "string"
+                }
+              ],
+              "conversionMethod": "pd.DataFrame",
+              "ref": "3b1d216f-422a-4f7f-a96e-a8192d575d10",
+              "rows": [
+                [
+                  "0",
+                  "What was Apple's total net sales for 2022?",
+                  "Apple's total net sales for the three months ended December 31, 2022, were $117,154 million"
+                ],
+                [
+                  "1",
+                  "What was Apple's Services revenue in Q1 2023 and what was the year-over-year growth rate?",
+                  "Apple's Services revenue was $20,766 million in Q1 2023, up from $19,516 million in Q1 2022, representing a 6% increase."
+                ],
+                [
+                  "2",
+                  "What was Apple's iPhone revenue in Q1 2026?",
+                  "I am an AI assistant created by Contextual AI. I don't have relevant documentation about that topic, but feel free to ask me something else!"
+                ],
+                [
+                  "3",
+                  "How much did Apple spend on research and development in 2022?",
+                  "Apple spent $7,709 million on research and development in Q1 2023."
+                ],
+                [
+                  "4",
+                  "What is the next amazing product from Apple?",
+                  "I am an AI assistant created by Contextual AI. I don't have relevant documentation about that topic, but feel free to ask me something else!"
+                ]
+              ],
+              "shape": {
+                "columns": 2,
+                "rows": 5
+              }
+            },
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>prompt</th>\n",
+              "      <th>reference</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>What was Apple's total net sales for 2022?</td>\n",
+              "      <td>Apple's total net sales for the three months e...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>What was Apple's Services revenue in Q1 2023 a...</td>\n",
+              "      <td>Apple's Services revenue was $20,766 million i...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>What was Apple's iPhone revenue in Q1 2026?</td>\n",
+              "      <td>I am an AI assistant created by Contextual AI....</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>How much did Apple spend on research and devel...</td>\n",
+              "      <td>Apple spent $7,709 million on research and dev...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>What is the next amazing product from Apple?</td>\n",
+              "      <td>I am an AI assistant created by Contextual AI....</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                                              prompt  \\\n",
+              "0         What was Apple's total net sales for 2022?   \n",
+              "1  What was Apple's Services revenue in Q1 2023 a...   \n",
+              "2        What was Apple's iPhone revenue in Q1 2026?   \n",
+              "3  How much did Apple spend on research and devel...   \n",
+              "4       What is the next amazing product from Apple?   \n",
+              "\n",
+              "                                           reference  \n",
+              "0  Apple's total net sales for the three months e...  \n",
+              "1  Apple's Services revenue was $20,766 million i...  \n",
+              "2  I am an AI assistant created by Contextual AI....  \n",
+              "3  Apple spent $7,709 million on research and dev...  \n",
+              "4  I am an AI assistant created by Contextual AI....  "
+            ]
+          },
+          "execution_count": 19,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "eval = pd.read_csv('data/eval_short.csv')\n",
         "eval.head()"
@@ -260,7 +437,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 20,
       "metadata": {
         "id": "YlLkLBJEQP1y"
       },
@@ -285,22 +462,41 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 21,
       "metadata": {
         "id": "bPGVo6DyQP1y"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "'83c54e9d-ef49-4143-84d7-a2027fbb38d8'"
+            ]
+          },
+          "execution_count": 21,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "eval_result.id"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 22,
       "metadata": {
         "id": "pb-H2cDcQP1y"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Evaluation Progress: 100%|██████████| 12/12 [00:00<00:00, 83330.54it/s]"
+          ]
+        }
+      ],
       "source": [
         "eval_status = client.agents.evaluate.jobs.metadata(agent_id=agent_id, job_id=eval_result.id)\n",
         "\n",
@@ -320,11 +516,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 23,
       "metadata": {
         "id": "8n-7k-gDQP1y"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "EvaluationJobMetadata(dataset_name='eval_short_83c54e9d-ef49-4143-84d7-a2027fbb38d8_results', job_metadata=JobMetadata(num_failed_predictions=0, num_predictions=12, num_successful_predictions=12, num_processed_predictions=12), metrics={'equivalence_score': {'score': 0.5833333333333334}, 'groundedness_score': {'score': 0.47222222222222227}}, status='completed')"
+            ]
+          },
+          "execution_count": 23,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "eval_status"
       ]
@@ -389,11 +596,302 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 25,
       "metadata": {
         "id": "agsodkxYQP1z"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+              "columns": [
+                {
+                  "name": "index",
+                  "rawType": "int64",
+                  "type": "integer"
+                },
+                {
+                  "name": "prompt",
+                  "rawType": "object",
+                  "type": "string"
+                },
+                {
+                  "name": "reference",
+                  "rawType": "object",
+                  "type": "string"
+                },
+                {
+                  "name": "response",
+                  "rawType": "object",
+                  "type": "string"
+                },
+                {
+                  "name": "guideline",
+                  "rawType": "object",
+                  "type": "string"
+                },
+                {
+                  "name": "knowledge",
+                  "rawType": "object",
+                  "type": "string"
+                },
+                {
+                  "name": "status",
+                  "rawType": "object",
+                  "type": "string"
+                },
+                {
+                  "name": "equivalence_score_score",
+                  "rawType": "float64",
+                  "type": "float"
+                },
+                {
+                  "name": "equivalence_score_metadata",
+                  "rawType": "object",
+                  "type": "string"
+                },
+                {
+                  "name": "factuality_v4.5_score_score",
+                  "rawType": "float64",
+                  "type": "float"
+                },
+                {
+                  "name": "factuality_v4.5_score_metadata",
+                  "rawType": "object",
+                  "type": "unknown"
+                }
+              ],
+              "conversionMethod": "pd.DataFrame",
+              "ref": "16e49d8e-2a77-4166-8d24-2b1aefde4513",
+              "rows": [
+                [
+                  "0",
+                  "What was Apple's total net sales for 2022?",
+                  "Apple's total net sales for the three months ended December 31, 2022, were $117,154 million",
+                  "I apologize, but I don't have access to Apple's financial data for 2022. For the most accurate and up-to-date information about Apple's net sales, I recommend checking their official financial reports or SEC filings.",
+                  "",
+                  "[]",
+                  "completed",
+                  "0.0",
+                  "The generated response does not provide the requested information about Apple's total net sales for 2022, instead offering a suggestion to check official financial reports or SEC filings.",
+                  "0.0",
+                  "{'description': 'There are claims but no knowledge so response is ungrounded.'}"
+                ],
+                [
+                  "1",
+                  "What was Apple's Services revenue in Q1 2023 and what was the year-over-year growth rate?",
+                  "Apple's Services revenue was $20,766 million in Q1 2023, up from $19,516 million in Q1 2022, representing a 6% increase.",
+                  "I am an AI assistant created by Contextual AI. I don't have relevant documentation about that topic, but feel free to ask me something else!",
+                  "",
+                  "[]",
+                  "completed",
+                  "0.0",
+                  "The generated response does not provide any information about Apple's Services revenue in Q1 2023 or the year-over-year growth rate, rendering it non-equivalent to the reference response.",
+                  "0.0",
+                  "{'description': 'There are claims but no knowledge so response is ungrounded.'}"
+                ],
+                [
+                  "2",
+                  "What was Apple's iPhone revenue in Q1 2026?",
+                  "I am an AI assistant created by Contextual AI. I don't have relevant documentation about that topic, but feel free to ask me something else!",
+                  "I am an AI assistant created by Contextual AI. I don't have relevant documentation about that topic, but feel free to ask me something else!",
+                  "",
+                  "[]",
+                  "completed",
+                  "1.0",
+                  "Both responses are semantically equivalent as they both state the AI assistant's inability to provide information on the topic, despite not directly answering the user's query.",
+                  "0.0",
+                  "{'description': 'There are claims but no knowledge so response is ungrounded.'}"
+                ],
+                [
+                  "3",
+                  "How much did Apple spend on research and development in 2022?",
+                  "Apple spent $7,709 million on research and development in Q1 2023.",
+                  "For the quarter ended December 31, 2022, Apple's research and development (R&D) expenses were $7,709 million. This represented 7% of their total net sales for the quarter.Based on my analysis, I cannot provide the full-year R&D spending for 2022 as I only have quarterly data. However, I can tell you that this represents a significant increase from the same quarter in the previous year, when R&D spending was $6,306 million (5% of net sales).",
+                  "",
+                  "[\"Section: FORM 10-Q\\nSub-Section: Operating Expenses\\n\\n\\nOperating expenses for the three months ended December 31, 2022 and December\\u00a025, 2021 were as follows (dollars in millions):\\n|  | Three Months Ended |  |\\n|-------------------------------------|----------------------|-------------------|\\n|  | December 31, 2022 | December 25, 2021 |\\n| Research and development | $ 7,709 | $ 6,306 |\\n| Percentage of total net sales | 7\\u00a0% | 5\\u00a0% |\\n| Selling, general and administrative | $ 6,607 | $ 6,449 |\\n| Percentage of total net sales | 6\\u00a0% | 5\\u00a0% |\\n| Total operating expenses | $ 14,316 | $ 12,755 |\\n| Percentage of total net sales | 12\\u00a0% | 10\\u00a0% |\"]",
+                  "completed",
+                  "1.0",
+                  "The generated response provides the same core information as the reference response, but with additional context and a clarification that the data is for a specific quarter, not the full year.",
+                  "0.8333333333333334",
+                  "{'claim_scores': [{'score': 'Supported', 'claim': \"For the quarter ended December 31, 2022, Apple's research and development (R&D) expenses were $7,709 million.\"}, {'score': 'Supported', 'claim': \"Apple's R&D expenses for the quarter ended December 31, 2022, represented 7% of their total net sales for the quarter.\"}, {'score': 'Unsupported', 'claim': 'The author cannot provide the full-year R&D spending for 2022 as they only have quarterly data.'}, {'score': 'Supported', 'claim': \"In the same quarter of the previous year, Apple's R&D spending was $6,306 million.\"}, {'score': 'Supported', 'claim': \"In the same quarter of the previous year, Apple's R&D spending represented 5% of net sales.\"}, {'score': 'Supported', 'claim': \"Apple's R&D spending for the quarter ended December 31, 2022, represents a significant increase from the same quarter in the previous year.\"}]}"
+                ],
+                [
+                  "4",
+                  "What is the next amazing product from Apple?",
+                  "I am an AI assistant created by Contextual AI. I don't have relevant documentation about that topic, but feel free to ask me something else!",
+                  "Apple's Recent Product Announcements:During the first quarter of 2023, Apple announced three new products:- A new iPad- A new iPad Pro powered by the Apple M2 chip- A new Apple TV 4K",
+                  "",
+                  "[\"Section: FORM 10-Q\\nSub-Section: Quarterly Highlights\\n\\n\\nTotal net sales decreased 5% or $6.8 billion during the first quarter of 2023 compared to the same quarter in 2022 due to the weakness in foreign currencies relative to the U.S. dollar. The weakness in foreign currencies contributed to lower net sales of iPhone and Mac, which was partially offset by higher net sales of iPad. \\u00ae During the first quarter of 2023, the Company announced a new iPad, a new iPad Pro  powered by the Apple M2 chip, and a new Apple TV 4K. The Company repurchased $19.0 billion of its common stock and paid dividends and dividend equivalents of $3.8 billion during the first quarter of 2023.\"]",
+                  "completed",
+                  "0.0",
+                  "The generated response provides specific information about Apple's recent product announcements, whereas the reference response states a lack of knowledge on the topic, making them fundamentally different in core information.",
+                  "1.0",
+                  "{'claim_scores': [{'score': 'Supported', 'claim': 'Apple announced three new products during the first quarter of 2023.'}, {'score': 'Supported', 'claim': 'One of the new products announced by Apple is a new iPad.'}, {'score': 'Supported', 'claim': 'One of the new products announced by Apple is a new iPad Pro powered by the Apple M2 chip.'}, {'score': 'Supported', 'claim': 'One of the new products announced by Apple is a new Apple TV 4K.'}]}"
+                ]
+              ],
+              "shape": {
+                "columns": 10,
+                "rows": 5
+              }
+            },
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>prompt</th>\n",
+              "      <th>reference</th>\n",
+              "      <th>response</th>\n",
+              "      <th>guideline</th>\n",
+              "      <th>knowledge</th>\n",
+              "      <th>status</th>\n",
+              "      <th>equivalence_score_score</th>\n",
+              "      <th>equivalence_score_metadata</th>\n",
+              "      <th>factuality_v4.5_score_score</th>\n",
+              "      <th>factuality_v4.5_score_metadata</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>What was Apple's total net sales for 2022?</td>\n",
+              "      <td>Apple's total net sales for the three months e...</td>\n",
+              "      <td>I apologize, but I don't have access to Apple'...</td>\n",
+              "      <td></td>\n",
+              "      <td>[]</td>\n",
+              "      <td>completed</td>\n",
+              "      <td>0.0</td>\n",
+              "      <td>The generated response does not provide the re...</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>{'description': 'There are claims but no knowl...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>What was Apple's Services revenue in Q1 2023 a...</td>\n",
+              "      <td>Apple's Services revenue was $20,766 million i...</td>\n",
+              "      <td>I am an AI assistant created by Contextual AI....</td>\n",
+              "      <td></td>\n",
+              "      <td>[]</td>\n",
+              "      <td>completed</td>\n",
+              "      <td>0.0</td>\n",
+              "      <td>The generated response does not provide any in...</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>{'description': 'There are claims but no knowl...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>What was Apple's iPhone revenue in Q1 2026?</td>\n",
+              "      <td>I am an AI assistant created by Contextual AI....</td>\n",
+              "      <td>I am an AI assistant created by Contextual AI....</td>\n",
+              "      <td></td>\n",
+              "      <td>[]</td>\n",
+              "      <td>completed</td>\n",
+              "      <td>1.0</td>\n",
+              "      <td>Both responses are semantically equivalent as ...</td>\n",
+              "      <td>0.000000</td>\n",
+              "      <td>{'description': 'There are claims but no knowl...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>How much did Apple spend on research and devel...</td>\n",
+              "      <td>Apple spent $7,709 million on research and dev...</td>\n",
+              "      <td>For the quarter ended December 31, 2022, Apple...</td>\n",
+              "      <td></td>\n",
+              "      <td>[\"Section: FORM 10-Q\\nSub-Section: Operating E...</td>\n",
+              "      <td>completed</td>\n",
+              "      <td>1.0</td>\n",
+              "      <td>The generated response provides the same core ...</td>\n",
+              "      <td>0.833333</td>\n",
+              "      <td>{'claim_scores': [{'score': 'Supported', 'clai...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>What is the next amazing product from Apple?</td>\n",
+              "      <td>I am an AI assistant created by Contextual AI....</td>\n",
+              "      <td>Apple's Recent Product Announcements:During th...</td>\n",
+              "      <td></td>\n",
+              "      <td>[\"Section: FORM 10-Q\\nSub-Section: Quarterly H...</td>\n",
+              "      <td>completed</td>\n",
+              "      <td>0.0</td>\n",
+              "      <td>The generated response provides specific infor...</td>\n",
+              "      <td>1.000000</td>\n",
+              "      <td>{'claim_scores': [{'score': 'Supported', 'clai...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                                              prompt  \\\n",
+              "0         What was Apple's total net sales for 2022?   \n",
+              "1  What was Apple's Services revenue in Q1 2023 a...   \n",
+              "2        What was Apple's iPhone revenue in Q1 2026?   \n",
+              "3  How much did Apple spend on research and devel...   \n",
+              "4       What is the next amazing product from Apple?   \n",
+              "\n",
+              "                                           reference  \\\n",
+              "0  Apple's total net sales for the three months e...   \n",
+              "1  Apple's Services revenue was $20,766 million i...   \n",
+              "2  I am an AI assistant created by Contextual AI....   \n",
+              "3  Apple spent $7,709 million on research and dev...   \n",
+              "4  I am an AI assistant created by Contextual AI....   \n",
+              "\n",
+              "                                            response guideline  \\\n",
+              "0  I apologize, but I don't have access to Apple'...             \n",
+              "1  I am an AI assistant created by Contextual AI....             \n",
+              "2  I am an AI assistant created by Contextual AI....             \n",
+              "3  For the quarter ended December 31, 2022, Apple...             \n",
+              "4  Apple's Recent Product Announcements:During th...             \n",
+              "\n",
+              "                                           knowledge     status  \\\n",
+              "0                                                 []  completed   \n",
+              "1                                                 []  completed   \n",
+              "2                                                 []  completed   \n",
+              "3  [\"Section: FORM 10-Q\\nSub-Section: Operating E...  completed   \n",
+              "4  [\"Section: FORM 10-Q\\nSub-Section: Quarterly H...  completed   \n",
+              "\n",
+              "   equivalence_score_score                         equivalence_score_metadata  \\\n",
+              "0                      0.0  The generated response does not provide the re...   \n",
+              "1                      0.0  The generated response does not provide any in...   \n",
+              "2                      1.0  Both responses are semantically equivalent as ...   \n",
+              "3                      1.0  The generated response provides the same core ...   \n",
+              "4                      0.0  The generated response provides specific infor...   \n",
+              "\n",
+              "   factuality_v4.5_score_score  \\\n",
+              "0                     0.000000   \n",
+              "1                     0.000000   \n",
+              "2                     0.000000   \n",
+              "3                     0.833333   \n",
+              "4                     1.000000   \n",
+              "\n",
+              "                      factuality_v4.5_score_metadata  \n",
+              "0  {'description': 'There are claims but no knowl...  \n",
+              "1  {'description': 'There are claims but no knowl...  \n",
+              "2  {'description': 'There are claims but no knowl...  \n",
+              "3  {'claim_scores': [{'score': 'Supported', 'clai...  \n",
+              "4  {'claim_scores': [{'score': 'Supported', 'clai...  "
+            ]
+          },
+          "execution_count": 25,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "eval_results = client.agents.datasets.evaluate.retrieve(dataset_name=eval_status.dataset_name, agent_id = agent_id)\n",
         "df = process_binary_evaluation(eval_results)\n",
@@ -442,11 +940,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 26,
       "metadata": {
         "id": "CnC-RTJUVMRA"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2.072\n"
+          ]
+        }
+      ],
       "source": [
         "response = client.lmunit.create(\n",
         "                    query=\"What material is used in N95 masks?\",\n",
@@ -484,7 +990,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 27,
       "metadata": {
         "id": "xi_cliANQP1z"
       },
@@ -516,11 +1022,31 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 28,
       "metadata": {
         "id": "ASRr5EPsQP1z"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "You are an AI assistant specialized in financial analysis and reporting. Your responses should be precise, accurate, and sourced exclusively from official financial documentation provided to you. Please follow these guidelines:\n",
+            "\n",
+            "Data Analysis & Response Quality:\n",
+            "* Only use information explicitly stated in provided documentation (e.g., earnings releases, financial statements, investor presentations)\n",
+            "* Present comparative analyses using structured formats with tables and bullet points where appropriate\n",
+            "* Include specific period-over-period comparisons (quarter-over-quarter, year-over-year) when relevant\n",
+            "* Maintain consistency in numerical presentations (e.g., consistent units, decimal places)\n",
+            "* Flag any one-time items or special charges that impact comparability\n",
+            "\n",
+            "\n",
+            "For any analysis, provide comprehensive insights using all relevant available information while maintaining strict adherence to these guidelines and focusing on delivering clear, actionable information.\n",
+            "\n"
+          ]
+        }
+      ],
       "source": [
         "client.agents.update(agent_id=agent_id, system_prompt=system_prompt2)\n",
         "\n",
@@ -563,7 +1089,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": 29,
       "metadata": {
         "id": "rUpThueoQP1z"
       },
@@ -661,11 +1187,108 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5: Filter Model / Prompt \n",
+        "\n",
+        "Filter prompts are used to reduce or filter the retrieved documents flowing to the Contextual AI Grounded Language Model (GLM). Specifically, it filter documents coming out of the reranker and prior to the GLM. For background, the flow of retrieved documents is: Retrievers --> Rerank --> Filter Prompt --> GLM\n",
+        "\n",
+        "A filter prompt is helpful for selecting relevant documents from a larger pool of documents. For example, \"if a query mentions a date, only select docs from within 6 months of that date\" or \"if a query mentions <customer-specific term>, exclude all docs without that term\"."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The filter prompt recently become customer facing, this snippet will be updated once it's integrated into the python SDK"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "headers = {\n",
+        "    \"accept\": \"application/json\",\n",
+        "    \"Content-Type\": \"application/json\",\n",
+        "    \"Authorization\": f\"Bearer {API_KEY}\"\n",
+        "}\n",
+        "\n",
+        "try:\n",
+        "    url = f\"https://api.contextual.ai/v1/agents/{agent_id}\"\n",
+        "\n",
+        "    payload = {\n",
+        "        \"filter_prompt\": \"Always reply with no\"\n",
+        "        #\"filter_prompt\": \"\"\n",
+        "    }\n",
+        "\n",
+        "    response = requests.put(\n",
+        "        url,\n",
+        "        headers=headers,\n",
+        "        json=payload\n",
+        "    )\n",
+        "    response.raise_for_status()\n",
+        "    if response.status_code == 200:\n",
+        "        try:\n",
+        "            metadata_url = f\"https://api.contextual.ai/v1/agents/{agent_id}/metadata\"\n",
+        "            metadata_response = requests.get(metadata_url, headers=headers)\n",
+        "            print(metadata_response.json())\n",
+        "        except requests.exceptions.RequestException as e:\n",
+        "            print(f\"Query failed: {str(e)}\")\n",
+        "            raise\n",
+        "except requests.exceptions.RequestException as e:\n",
+        "    print(f\"Query failed: {str(e)}\")\n",
+        "    raise"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Let's verify the filter prompt has been modified."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "agent_config = client.agents.metadata(agent_id=agent_id)\n",
+        "print (agent_config.filter_prompt)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "This filter prompt will refuse to answer for this example. We can verify that with a new query."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "query_result = client.agents.query.create(\n",
+        "    agent_id=agent_id,\n",
+        "    messages=[{\n",
+        "        \"content\": \"what was the sales for Apple in 2022\",\n",
+        "        \"role\": \"user\"\n",
+        "    }]\n",
+        ")\n",
+        "print(query_result.message.content)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "AXfZf3SnQP10"
       },
       "source": [
-        "## 5: Generation Settings\n",
+        "## 6: Generation Settings\n",
         "\n",
         "There are a number of settings available for modifying the generation of responses. These are advanced settings, please refer to the documentation for more details.\n",
         "\n",
@@ -678,7 +1301,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
+      "execution_count": 30,
       "metadata": {
         "id": "9KaBgYPaQP10"
       },
@@ -703,11 +1326,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 31,
       "metadata": {
         "id": "dRLX7QlAQP10"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "{'retrieval_config': {'top_k_retrieved_chunks': 10, 'lexical_alpha': 0.5, 'semantic_alpha': 0.5, 'num_retrieved_docs': 11}, 'generate_response_config': {'max_new_tokens': 500, 'temperature': 0.7, 'top_p': 0.95, 'frequency_penalty': 0.5}}\n"
+          ]
+        }
+      ],
       "source": [
         "agent_info = client.agents.metadata(agent_id=agent_id)\n",
         "print(agent_info.agent_configs)"
@@ -719,7 +1350,7 @@
         "id": "692gSc7ZNyve"
       },
       "source": [
-        "## 6: Tune your Agent\n",
+        "## 7: Tune your Agent\n",
         "\n",
         "Contextual AI allows you to tune your entire agent end to end for improved performance. To run a tune job, you need to specify a training file and an optional test file. (If no test file is provided, the tuning job will hold out a portion of the training file as the test set.)\n",
         "\n",
@@ -734,7 +1365,7 @@
         "id": "dmRrBTy0OWzc"
       },
       "source": [
-        "### 6.1 Format for the Training File\n",
+        "### 7.1 Format for the Training File\n",
         "\n",
         "The file should be in JSON array format, where each element of the array is a JSON object represents a single training example. The four required fields are guideline, prompt, reference, and knowledge.\n",
         "\n",
@@ -751,11 +1382,28 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 32,
       "metadata": {
         "id": "Rf1DeSP-VXR4"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "{\"guideline\": \"The response should analyze key financial metrics and trends.\", \"prompt\": \"What were Apple's key revenue metrics for Q1 2023?\", \"knowledge\": [\"Total net sales were $117.2 billion, down 5% YoY.\", \"Products revenue was $96.4 billion, down from $104.4 billion.\", \"Services revenue grew to $20.8 billion from $19.5 billion.\", \"iPhone revenue decreased 8% YoY to $65.8 billion.\"], \"reference\": \"Apple's Q1 2023 showed total net sales of $117.2 billion (down 5% YoY), with Products revenue declining to $96.4 billion while Services grew to $20.8 billion. iPhone revenue decreased 8% YoY to $65.8 billion.\"}\n",
+            "{\"guideline\": \"The response should highlight segment performance and geographic trends.\", \"prompt\": \"How did Apple's geographic segments perform in Q1 2023?\", \"knowledge\": [\"Americas revenue declined 4% to $49.3 billion.\", \"Europe revenue decreased 7% to $27.7 billion.\", \"Greater China revenue fell 7% to $23.9 billion.\", \"Japan revenue declined 5% to $6.8 billion.\", \"Rest of Asia Pacific down 3% to $9.5 billion.\"], \"reference\": \"Apple's Q1 2023 geographic performance showed declines across all regions: Americas (-4% to $49.3B), Europe (-7% to $27.7B), Greater China (-7% to $23.9B), Japan (-5% to $6.8B), and Rest of Asia Pacific (-3% to $9.5B).\"}\n",
+            "{\"guideline\": \"The response should analyze profitability metrics and margins.\", \"prompt\": \"What were Apple's key profitability metrics in Q1 2023?\", \"knowledge\": [\"Gross margin was $50.3 billion or 43.0% of revenue.\", \"Operating income was $36.0 billion.\", \"Net income was $30.0 billion.\", \"Diluted earnings per share was $1.88.\"], \"reference\": \"Apple achieved gross margin of $50.3 billion (43.0% of revenue) in Q1 2023, with operating income of $36.0 billion and net income of $30.0 billion, resulting in diluted earnings per share of $1.88.\"}\n",
+            "{\"guideline\": \"The response should focus on segment margin analysis.\", \"prompt\": \"How did Apple's Products and Services margins compare in Q1 2023?\", \"knowledge\": [\"Products gross margin was 37.0%, down from 38.4%.\", \"Services gross margin was 70.8%, down from 72.4%.\", \"Products gross margin was impacted by foreign exchange.\", \"Services costs increased while leverage improved.\"], \"reference\": \"Apple's Q1 2023 segment margins showed Products gross margin of 37.0% (down from 38.4%) and Services gross margin of 70.8% (down from 72.4%), with Products impacted by foreign exchange while Services saw higher costs offset by improved leverage.\"}\n",
+            "{\"guideline\": \"The response should analyze balance sheet strength and liquidity.\", \"prompt\": \"What was Apple's cash and debt position at the end of Q1 2023?\", \"knowledge\": [\"Cash and marketable securities totaled $165.5 billion.\", \"Total term debt was $109.4 billion.\", \"Commercial paper outstanding was $1.7 billion.\", \"Generated operating cash flow of $34.0 billion in Q1.\"], \"reference\": \"Apple maintained a strong financial position with $165.5 billion in cash and marketable securities against $109.4 billion in term debt and $1.7 billion in commercial paper, while generating $34.0 billion in Q1 operating cash flow.\"}\n",
+            "{\"guideline\": \"The response should focus on key business metrics and operational performance.\", \"prompt\": \"How did Apple's product categories perform in Q1 2023?\", \"knowledge\": [\"iPhone revenue declined 8% to $65.8 billion.\", \"Mac revenue fell 29% to $7.7 billion.\", \"iPad revenue grew 30% to $9.4 billion.\", \"Wearables revenue decreased 8% to $13.5 billion.\", \"Services reached an all-time high of $20.8 billion.\"], \"reference\": \"Apple's Q1 2023 product performance was mixed, with iPhone (-8% to $65.8B), Mac (-29% to $7.7B), and Wearables (-8% to $13.5B) declining, while iPad grew 30% to $9.4B and Services hit a record $20.8B.\"}\n",
+            "{\"guideline\": \"The response should analyze capital return and shareholder value.\", \"prompt\": \"What actions did Apple take to return capital to shareholders in Q1 2023?\", \"knowledge\": [\"Repurchased $19.0 billion of common stock.\", \"Paid $3.8 billion in dividends and equivalents.\", \"Declared dividend of $0.23 per share.\", \"Reduced share count by approximately 133 million shares.\"], \"reference\": \"Apple returned capital to shareholders through $19.0 billion in share repurchases and $3.8 billion in dividends in Q1 2023, with a $0.23 per share dividend and net reduction of approximately 133 million shares outstanding.\"}\n",
+            "{\"guideline\": \"The response should focus on expense management and operational efficiency.\", \"prompt\": \"How did Apple's operating expenses change in Q1 2023?\", \"knowledge\": [\"R&D expenses increased to $7.7 billion from $6.3 billion.\", \"SG&A expenses remained relatively flat at $6.6 billion.\", \"Total operating expenses were $14.3 billion or 12% of revenue.\", \"Headcount-related expenses drove R&D growth.\"], \"reference\": \"Apple's Q1 2023 operating expenses totaled $14.3 billion (12% of revenue), with R&D increasing to $7.7 billion due to higher headcount costs while SG&A remained stable at $6.6 billion.\"}\n",
+            "{\"guideline\": \"The response should analyze working capital and operational metrics.\", \"prompt\": \"How did Apple's working capital metrics change in Q1 2023?\", \"knowledge\": [\"Accounts receivable decreased to $23.8 billion.\", \"Inventories increased to $6.8 billion.\", \"Accounts payable decreased to $57.9 billion.\", \"Vendor non-trade receivables were $30.4 billion.\"], \"reference\": \"Apple's Q1 2023 working capital showed accounts receivable of $23.8 billion, increased inventories of $6.8 billion, accounts payable of $57.9 billion, and vendor non-trade receivables of $30.4 billion.\"}\n",
+            "{\"guideline\": \"The response should focus on tax strategy and effective rates.\", \"prompt\": \"What was Apple's tax position in Q1 2023?\", \"knowledge\": [\"Effective tax rate was 15.8%.\", \"Provision for income taxes was $5.6 billion.\", \"Lower rate driven by foreign earnings differences.\", \"Benefited from R&D credits and share-based compensation.\"], \"reference\": \"Apple's Q1 2023 effective tax rate was 15.8% with a tax provision of $5.6 billion, benefiting from foreign earnings differentials, R&D credits, and tax benefits from share-based compensation.\"}\n"
+          ]
+        }
+      ],
       "source": [
         "!head data/fin_train.jsonl"
       ]
@@ -766,7 +1414,7 @@
         "id": "R1tcNqTv0gaQ"
       },
       "source": [
-        "### 6.2 Starting a Tuning Model Job"
+        "### 7.2 Starting a Tuning Model Job"
       ]
     },
     {
@@ -793,7 +1441,7 @@
         "id": "NGao-yw7yLVY"
       },
       "source": [
-        " ### 6.3 Checking the Status.\n",
+        " ### 7.3 Checking the Status.\n",
         "\n",
         " You can check the status of the job. For detailed information, refer to the API documentation. When the tuning job is complete, the status will turn to completed. The response payload will also contain evaluation_results ."
       ]
@@ -835,7 +1483,7 @@
         "id": "M_77uMH5ybBh"
       },
       "source": [
-        "### 6.4 Updating the agent\n",
+        "### 7.4 Updating the agent\n",
         "Once the tuned job is complete, you can deploy the tuned model via editing the agent through API. Note that currently a single fine-tuned model deployment is allowed per tenant. Please see the API doc for more information."
       ]
     },
@@ -875,7 +1523,7 @@
         "id": "akE9XOq9NTEc"
       },
       "source": [
-        "### 6.5 Query your tuned model\n",
+        "### 7.5 Query your tuned model\n",
         "After you have deployed the tuned model, you can now query it with the usual command. Make sure you pass your new tuned model_id in."
       ]
     },

--- a/06-improve-agent-performance/improvement-overview.ipynb
+++ b/06-improve-agent-performance/improvement-overview.ipynb
@@ -80,7 +80,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -88,16 +88,7 @@
         "id": "hUk8u_lSOArL",
         "outputId": "a79c80a1-5772-4078-e32b-b58119fd32dd"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Fetching data/eval_short.csv\n",
-            "Fetching data/fin_train.jsonl\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "def fetch_file(filepath):\n",
         "    if not os.path.exists(os.path.dirname(filepath)):  # Ensure the directory exists\n",
@@ -143,7 +134,7 @@
       },
       "outputs": [],
       "source": [
-        "agent_id = 'eea5bd52-e207-4761-98ff-e2f6536eb5ee'"
+        "agent_id = 'ADD_AGENT_ID'"
       ]
     },
     {
@@ -183,29 +174,12 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": null,
       "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Apple's total net sales for the quarter ended December 31, 2022 were $117.2 billion, representing a 5% decrease from $123.9 billion in the same quarter of 2021.[2]()[3]() This decline was primarily attributed to foreign currency weakness against the U.S. dollar.[1]()\n",
-            "\n",
-            "Product Segment Performance:\n",
-            "- iPhone: $65.8 billion (down 8% year-over-year)[2]()[3]()\n",
-            "- Mac: $7.7 billion (down 29% year-over-year)[2]()[3]()\n",
-            "- iPad: $9.4 billion (up 30% year-over-year)[2]()[3]()\n",
-            "- Wearables, Home and Accessories: $13.5 billion (down 8% year-over-year)[2]()[3]()\n",
-            "- Services: $20.8 billion (up 6% year-over-year)[2]()[3]()\n",
-            "\n",
-            "The iPhone sales decrease was primarily due to lower sales of new iPhone models launched in the fourth quarter of 2022.[4]() The Mac segment decline was mainly driven by decreased MacBook Pro sales.[5]()\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "content = query_result.message.content\n",
-        "print(content)"
+        "content"
       ]
     },
     {
@@ -219,26 +193,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": null,
       "metadata": {
         "id": "aR-rCnf5QP1x"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Section: FORM 10-Q\n",
-            "Sub-Section: iPhone\n",
-            "\n",
-            "\n",
-            "iPhone net sales decreased during the first quarter of 2023 compared to the same quarter in 2022 due primarily to lower net sales from the Company’s new iPhone models launched in the fourth quarter of 2022.\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "context_text = query_result.retrieval_contents[3].content_text\n",
-        "print(context_text)"
+        "context_text"
       ]
     },
     {
@@ -288,139 +250,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": null,
       "metadata": {
         "id": "zeue_glVQP1y"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-              "columns": [
-                {
-                  "name": "index",
-                  "rawType": "int64",
-                  "type": "integer"
-                },
-                {
-                  "name": "prompt",
-                  "rawType": "object",
-                  "type": "string"
-                },
-                {
-                  "name": "reference",
-                  "rawType": "object",
-                  "type": "string"
-                }
-              ],
-              "conversionMethod": "pd.DataFrame",
-              "ref": "3b1d216f-422a-4f7f-a96e-a8192d575d10",
-              "rows": [
-                [
-                  "0",
-                  "What was Apple's total net sales for 2022?",
-                  "Apple's total net sales for the three months ended December 31, 2022, were $117,154 million"
-                ],
-                [
-                  "1",
-                  "What was Apple's Services revenue in Q1 2023 and what was the year-over-year growth rate?",
-                  "Apple's Services revenue was $20,766 million in Q1 2023, up from $19,516 million in Q1 2022, representing a 6% increase."
-                ],
-                [
-                  "2",
-                  "What was Apple's iPhone revenue in Q1 2026?",
-                  "I am an AI assistant created by Contextual AI. I don't have relevant documentation about that topic, but feel free to ask me something else!"
-                ],
-                [
-                  "3",
-                  "How much did Apple spend on research and development in 2022?",
-                  "Apple spent $7,709 million on research and development in Q1 2023."
-                ],
-                [
-                  "4",
-                  "What is the next amazing product from Apple?",
-                  "I am an AI assistant created by Contextual AI. I don't have relevant documentation about that topic, but feel free to ask me something else!"
-                ]
-              ],
-              "shape": {
-                "columns": 2,
-                "rows": 5
-              }
-            },
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>prompt</th>\n",
-              "      <th>reference</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>What was Apple's total net sales for 2022?</td>\n",
-              "      <td>Apple's total net sales for the three months e...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>What was Apple's Services revenue in Q1 2023 a...</td>\n",
-              "      <td>Apple's Services revenue was $20,766 million i...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>What was Apple's iPhone revenue in Q1 2026?</td>\n",
-              "      <td>I am an AI assistant created by Contextual AI....</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>How much did Apple spend on research and devel...</td>\n",
-              "      <td>Apple spent $7,709 million on research and dev...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>What is the next amazing product from Apple?</td>\n",
-              "      <td>I am an AI assistant created by Contextual AI....</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>"
-            ],
-            "text/plain": [
-              "                                              prompt  \\\n",
-              "0         What was Apple's total net sales for 2022?   \n",
-              "1  What was Apple's Services revenue in Q1 2023 a...   \n",
-              "2        What was Apple's iPhone revenue in Q1 2026?   \n",
-              "3  How much did Apple spend on research and devel...   \n",
-              "4       What is the next amazing product from Apple?   \n",
-              "\n",
-              "                                           reference  \n",
-              "0  Apple's total net sales for the three months e...  \n",
-              "1  Apple's Services revenue was $20,766 million i...  \n",
-              "2  I am an AI assistant created by Contextual AI....  \n",
-              "3  Apple spent $7,709 million on research and dev...  \n",
-              "4  I am an AI assistant created by Contextual AI....  "
-            ]
-          },
-          "execution_count": 19,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "eval = pd.read_csv('data/eval_short.csv')\n",
         "eval.head()"
@@ -462,41 +296,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": null,
       "metadata": {
         "id": "bPGVo6DyQP1y"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "'83c54e9d-ef49-4143-84d7-a2027fbb38d8'"
-            ]
-          },
-          "execution_count": 21,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "eval_result.id"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": null,
       "metadata": {
         "id": "pb-H2cDcQP1y"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Evaluation Progress: 100%|██████████| 12/12 [00:00<00:00, 83330.54it/s]"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "eval_status = client.agents.evaluate.jobs.metadata(agent_id=agent_id, job_id=eval_result.id)\n",
         "\n",
@@ -516,22 +331,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 23,
+      "execution_count": null,
       "metadata": {
         "id": "8n-7k-gDQP1y"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "EvaluationJobMetadata(dataset_name='eval_short_83c54e9d-ef49-4143-84d7-a2027fbb38d8_results', job_metadata=JobMetadata(num_failed_predictions=0, num_predictions=12, num_successful_predictions=12, num_processed_predictions=12), metrics={'equivalence_score': {'score': 0.5833333333333334}, 'groundedness_score': {'score': 0.47222222222222227}}, status='completed')"
-            ]
-          },
-          "execution_count": 23,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "eval_status"
       ]
@@ -596,302 +400,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 25,
+      "execution_count": null,
       "metadata": {
         "id": "agsodkxYQP1z"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-              "columns": [
-                {
-                  "name": "index",
-                  "rawType": "int64",
-                  "type": "integer"
-                },
-                {
-                  "name": "prompt",
-                  "rawType": "object",
-                  "type": "string"
-                },
-                {
-                  "name": "reference",
-                  "rawType": "object",
-                  "type": "string"
-                },
-                {
-                  "name": "response",
-                  "rawType": "object",
-                  "type": "string"
-                },
-                {
-                  "name": "guideline",
-                  "rawType": "object",
-                  "type": "string"
-                },
-                {
-                  "name": "knowledge",
-                  "rawType": "object",
-                  "type": "string"
-                },
-                {
-                  "name": "status",
-                  "rawType": "object",
-                  "type": "string"
-                },
-                {
-                  "name": "equivalence_score_score",
-                  "rawType": "float64",
-                  "type": "float"
-                },
-                {
-                  "name": "equivalence_score_metadata",
-                  "rawType": "object",
-                  "type": "string"
-                },
-                {
-                  "name": "factuality_v4.5_score_score",
-                  "rawType": "float64",
-                  "type": "float"
-                },
-                {
-                  "name": "factuality_v4.5_score_metadata",
-                  "rawType": "object",
-                  "type": "unknown"
-                }
-              ],
-              "conversionMethod": "pd.DataFrame",
-              "ref": "16e49d8e-2a77-4166-8d24-2b1aefde4513",
-              "rows": [
-                [
-                  "0",
-                  "What was Apple's total net sales for 2022?",
-                  "Apple's total net sales for the three months ended December 31, 2022, were $117,154 million",
-                  "I apologize, but I don't have access to Apple's financial data for 2022. For the most accurate and up-to-date information about Apple's net sales, I recommend checking their official financial reports or SEC filings.",
-                  "",
-                  "[]",
-                  "completed",
-                  "0.0",
-                  "The generated response does not provide the requested information about Apple's total net sales for 2022, instead offering a suggestion to check official financial reports or SEC filings.",
-                  "0.0",
-                  "{'description': 'There are claims but no knowledge so response is ungrounded.'}"
-                ],
-                [
-                  "1",
-                  "What was Apple's Services revenue in Q1 2023 and what was the year-over-year growth rate?",
-                  "Apple's Services revenue was $20,766 million in Q1 2023, up from $19,516 million in Q1 2022, representing a 6% increase.",
-                  "I am an AI assistant created by Contextual AI. I don't have relevant documentation about that topic, but feel free to ask me something else!",
-                  "",
-                  "[]",
-                  "completed",
-                  "0.0",
-                  "The generated response does not provide any information about Apple's Services revenue in Q1 2023 or the year-over-year growth rate, rendering it non-equivalent to the reference response.",
-                  "0.0",
-                  "{'description': 'There are claims but no knowledge so response is ungrounded.'}"
-                ],
-                [
-                  "2",
-                  "What was Apple's iPhone revenue in Q1 2026?",
-                  "I am an AI assistant created by Contextual AI. I don't have relevant documentation about that topic, but feel free to ask me something else!",
-                  "I am an AI assistant created by Contextual AI. I don't have relevant documentation about that topic, but feel free to ask me something else!",
-                  "",
-                  "[]",
-                  "completed",
-                  "1.0",
-                  "Both responses are semantically equivalent as they both state the AI assistant's inability to provide information on the topic, despite not directly answering the user's query.",
-                  "0.0",
-                  "{'description': 'There are claims but no knowledge so response is ungrounded.'}"
-                ],
-                [
-                  "3",
-                  "How much did Apple spend on research and development in 2022?",
-                  "Apple spent $7,709 million on research and development in Q1 2023.",
-                  "For the quarter ended December 31, 2022, Apple's research and development (R&D) expenses were $7,709 million. This represented 7% of their total net sales for the quarter.Based on my analysis, I cannot provide the full-year R&D spending for 2022 as I only have quarterly data. However, I can tell you that this represents a significant increase from the same quarter in the previous year, when R&D spending was $6,306 million (5% of net sales).",
-                  "",
-                  "[\"Section: FORM 10-Q\\nSub-Section: Operating Expenses\\n\\n\\nOperating expenses for the three months ended December 31, 2022 and December\\u00a025, 2021 were as follows (dollars in millions):\\n|  | Three Months Ended |  |\\n|-------------------------------------|----------------------|-------------------|\\n|  | December 31, 2022 | December 25, 2021 |\\n| Research and development | $ 7,709 | $ 6,306 |\\n| Percentage of total net sales | 7\\u00a0% | 5\\u00a0% |\\n| Selling, general and administrative | $ 6,607 | $ 6,449 |\\n| Percentage of total net sales | 6\\u00a0% | 5\\u00a0% |\\n| Total operating expenses | $ 14,316 | $ 12,755 |\\n| Percentage of total net sales | 12\\u00a0% | 10\\u00a0% |\"]",
-                  "completed",
-                  "1.0",
-                  "The generated response provides the same core information as the reference response, but with additional context and a clarification that the data is for a specific quarter, not the full year.",
-                  "0.8333333333333334",
-                  "{'claim_scores': [{'score': 'Supported', 'claim': \"For the quarter ended December 31, 2022, Apple's research and development (R&D) expenses were $7,709 million.\"}, {'score': 'Supported', 'claim': \"Apple's R&D expenses for the quarter ended December 31, 2022, represented 7% of their total net sales for the quarter.\"}, {'score': 'Unsupported', 'claim': 'The author cannot provide the full-year R&D spending for 2022 as they only have quarterly data.'}, {'score': 'Supported', 'claim': \"In the same quarter of the previous year, Apple's R&D spending was $6,306 million.\"}, {'score': 'Supported', 'claim': \"In the same quarter of the previous year, Apple's R&D spending represented 5% of net sales.\"}, {'score': 'Supported', 'claim': \"Apple's R&D spending for the quarter ended December 31, 2022, represents a significant increase from the same quarter in the previous year.\"}]}"
-                ],
-                [
-                  "4",
-                  "What is the next amazing product from Apple?",
-                  "I am an AI assistant created by Contextual AI. I don't have relevant documentation about that topic, but feel free to ask me something else!",
-                  "Apple's Recent Product Announcements:During the first quarter of 2023, Apple announced three new products:- A new iPad- A new iPad Pro powered by the Apple M2 chip- A new Apple TV 4K",
-                  "",
-                  "[\"Section: FORM 10-Q\\nSub-Section: Quarterly Highlights\\n\\n\\nTotal net sales decreased 5% or $6.8 billion during the first quarter of 2023 compared to the same quarter in 2022 due to the weakness in foreign currencies relative to the U.S. dollar. The weakness in foreign currencies contributed to lower net sales of iPhone and Mac, which was partially offset by higher net sales of iPad. \\u00ae During the first quarter of 2023, the Company announced a new iPad, a new iPad Pro  powered by the Apple M2 chip, and a new Apple TV 4K. The Company repurchased $19.0 billion of its common stock and paid dividends and dividend equivalents of $3.8 billion during the first quarter of 2023.\"]",
-                  "completed",
-                  "0.0",
-                  "The generated response provides specific information about Apple's recent product announcements, whereas the reference response states a lack of knowledge on the topic, making them fundamentally different in core information.",
-                  "1.0",
-                  "{'claim_scores': [{'score': 'Supported', 'claim': 'Apple announced three new products during the first quarter of 2023.'}, {'score': 'Supported', 'claim': 'One of the new products announced by Apple is a new iPad.'}, {'score': 'Supported', 'claim': 'One of the new products announced by Apple is a new iPad Pro powered by the Apple M2 chip.'}, {'score': 'Supported', 'claim': 'One of the new products announced by Apple is a new Apple TV 4K.'}]}"
-                ]
-              ],
-              "shape": {
-                "columns": 10,
-                "rows": 5
-              }
-            },
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>prompt</th>\n",
-              "      <th>reference</th>\n",
-              "      <th>response</th>\n",
-              "      <th>guideline</th>\n",
-              "      <th>knowledge</th>\n",
-              "      <th>status</th>\n",
-              "      <th>equivalence_score_score</th>\n",
-              "      <th>equivalence_score_metadata</th>\n",
-              "      <th>factuality_v4.5_score_score</th>\n",
-              "      <th>factuality_v4.5_score_metadata</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>What was Apple's total net sales for 2022?</td>\n",
-              "      <td>Apple's total net sales for the three months e...</td>\n",
-              "      <td>I apologize, but I don't have access to Apple'...</td>\n",
-              "      <td></td>\n",
-              "      <td>[]</td>\n",
-              "      <td>completed</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>The generated response does not provide the re...</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>{'description': 'There are claims but no knowl...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>What was Apple's Services revenue in Q1 2023 a...</td>\n",
-              "      <td>Apple's Services revenue was $20,766 million i...</td>\n",
-              "      <td>I am an AI assistant created by Contextual AI....</td>\n",
-              "      <td></td>\n",
-              "      <td>[]</td>\n",
-              "      <td>completed</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>The generated response does not provide any in...</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>{'description': 'There are claims but no knowl...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>What was Apple's iPhone revenue in Q1 2026?</td>\n",
-              "      <td>I am an AI assistant created by Contextual AI....</td>\n",
-              "      <td>I am an AI assistant created by Contextual AI....</td>\n",
-              "      <td></td>\n",
-              "      <td>[]</td>\n",
-              "      <td>completed</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>Both responses are semantically equivalent as ...</td>\n",
-              "      <td>0.000000</td>\n",
-              "      <td>{'description': 'There are claims but no knowl...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>How much did Apple spend on research and devel...</td>\n",
-              "      <td>Apple spent $7,709 million on research and dev...</td>\n",
-              "      <td>For the quarter ended December 31, 2022, Apple...</td>\n",
-              "      <td></td>\n",
-              "      <td>[\"Section: FORM 10-Q\\nSub-Section: Operating E...</td>\n",
-              "      <td>completed</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>The generated response provides the same core ...</td>\n",
-              "      <td>0.833333</td>\n",
-              "      <td>{'claim_scores': [{'score': 'Supported', 'clai...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>What is the next amazing product from Apple?</td>\n",
-              "      <td>I am an AI assistant created by Contextual AI....</td>\n",
-              "      <td>Apple's Recent Product Announcements:During th...</td>\n",
-              "      <td></td>\n",
-              "      <td>[\"Section: FORM 10-Q\\nSub-Section: Quarterly H...</td>\n",
-              "      <td>completed</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>The generated response provides specific infor...</td>\n",
-              "      <td>1.000000</td>\n",
-              "      <td>{'claim_scores': [{'score': 'Supported', 'clai...</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>"
-            ],
-            "text/plain": [
-              "                                              prompt  \\\n",
-              "0         What was Apple's total net sales for 2022?   \n",
-              "1  What was Apple's Services revenue in Q1 2023 a...   \n",
-              "2        What was Apple's iPhone revenue in Q1 2026?   \n",
-              "3  How much did Apple spend on research and devel...   \n",
-              "4       What is the next amazing product from Apple?   \n",
-              "\n",
-              "                                           reference  \\\n",
-              "0  Apple's total net sales for the three months e...   \n",
-              "1  Apple's Services revenue was $20,766 million i...   \n",
-              "2  I am an AI assistant created by Contextual AI....   \n",
-              "3  Apple spent $7,709 million on research and dev...   \n",
-              "4  I am an AI assistant created by Contextual AI....   \n",
-              "\n",
-              "                                            response guideline  \\\n",
-              "0  I apologize, but I don't have access to Apple'...             \n",
-              "1  I am an AI assistant created by Contextual AI....             \n",
-              "2  I am an AI assistant created by Contextual AI....             \n",
-              "3  For the quarter ended December 31, 2022, Apple...             \n",
-              "4  Apple's Recent Product Announcements:During th...             \n",
-              "\n",
-              "                                           knowledge     status  \\\n",
-              "0                                                 []  completed   \n",
-              "1                                                 []  completed   \n",
-              "2                                                 []  completed   \n",
-              "3  [\"Section: FORM 10-Q\\nSub-Section: Operating E...  completed   \n",
-              "4  [\"Section: FORM 10-Q\\nSub-Section: Quarterly H...  completed   \n",
-              "\n",
-              "   equivalence_score_score                         equivalence_score_metadata  \\\n",
-              "0                      0.0  The generated response does not provide the re...   \n",
-              "1                      0.0  The generated response does not provide any in...   \n",
-              "2                      1.0  Both responses are semantically equivalent as ...   \n",
-              "3                      1.0  The generated response provides the same core ...   \n",
-              "4                      0.0  The generated response provides specific infor...   \n",
-              "\n",
-              "   factuality_v4.5_score_score  \\\n",
-              "0                     0.000000   \n",
-              "1                     0.000000   \n",
-              "2                     0.000000   \n",
-              "3                     0.833333   \n",
-              "4                     1.000000   \n",
-              "\n",
-              "                      factuality_v4.5_score_metadata  \n",
-              "0  {'description': 'There are claims but no knowl...  \n",
-              "1  {'description': 'There are claims but no knowl...  \n",
-              "2  {'description': 'There are claims but no knowl...  \n",
-              "3  {'claim_scores': [{'score': 'Supported', 'clai...  \n",
-              "4  {'claim_scores': [{'score': 'Supported', 'clai...  "
-            ]
-          },
-          "execution_count": 25,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "eval_results = client.agents.datasets.evaluate.retrieve(dataset_name=eval_status.dataset_name, agent_id = agent_id)\n",
         "df = process_binary_evaluation(eval_results)\n",
@@ -940,19 +453,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
+      "execution_count": null,
       "metadata": {
         "id": "CnC-RTJUVMRA"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "2.072\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "response = client.lmunit.create(\n",
         "                    query=\"What material is used in N95 masks?\",\n",
@@ -1022,31 +527,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 28,
+      "execution_count": null,
       "metadata": {
         "id": "ASRr5EPsQP1z"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "You are an AI assistant specialized in financial analysis and reporting. Your responses should be precise, accurate, and sourced exclusively from official financial documentation provided to you. Please follow these guidelines:\n",
-            "\n",
-            "Data Analysis & Response Quality:\n",
-            "* Only use information explicitly stated in provided documentation (e.g., earnings releases, financial statements, investor presentations)\n",
-            "* Present comparative analyses using structured formats with tables and bullet points where appropriate\n",
-            "* Include specific period-over-period comparisons (quarter-over-quarter, year-over-year) when relevant\n",
-            "* Maintain consistency in numerical presentations (e.g., consistent units, decimal places)\n",
-            "* Flag any one-time items or special charges that impact comparability\n",
-            "\n",
-            "\n",
-            "For any analysis, provide comprehensive insights using all relevant available information while maintaining strict adherence to these guidelines and focusing on delivering clear, actionable information.\n",
-            "\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "client.agents.update(agent_id=agent_id, system_prompt=system_prompt2)\n",
         "\n",
@@ -1326,19 +811,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 31,
+      "execution_count": null,
       "metadata": {
         "id": "dRLX7QlAQP10"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "{'retrieval_config': {'top_k_retrieved_chunks': 10, 'lexical_alpha': 0.5, 'semantic_alpha': 0.5, 'num_retrieved_docs': 11}, 'generate_response_config': {'max_new_tokens': 500, 'temperature': 0.7, 'top_p': 0.95, 'frequency_penalty': 0.5}}\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "agent_info = client.agents.metadata(agent_id=agent_id)\n",
         "print(agent_info.agent_configs)"
@@ -1382,28 +859,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 32,
+      "execution_count": null,
       "metadata": {
         "id": "Rf1DeSP-VXR4"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "{\"guideline\": \"The response should analyze key financial metrics and trends.\", \"prompt\": \"What were Apple's key revenue metrics for Q1 2023?\", \"knowledge\": [\"Total net sales were $117.2 billion, down 5% YoY.\", \"Products revenue was $96.4 billion, down from $104.4 billion.\", \"Services revenue grew to $20.8 billion from $19.5 billion.\", \"iPhone revenue decreased 8% YoY to $65.8 billion.\"], \"reference\": \"Apple's Q1 2023 showed total net sales of $117.2 billion (down 5% YoY), with Products revenue declining to $96.4 billion while Services grew to $20.8 billion. iPhone revenue decreased 8% YoY to $65.8 billion.\"}\n",
-            "{\"guideline\": \"The response should highlight segment performance and geographic trends.\", \"prompt\": \"How did Apple's geographic segments perform in Q1 2023?\", \"knowledge\": [\"Americas revenue declined 4% to $49.3 billion.\", \"Europe revenue decreased 7% to $27.7 billion.\", \"Greater China revenue fell 7% to $23.9 billion.\", \"Japan revenue declined 5% to $6.8 billion.\", \"Rest of Asia Pacific down 3% to $9.5 billion.\"], \"reference\": \"Apple's Q1 2023 geographic performance showed declines across all regions: Americas (-4% to $49.3B), Europe (-7% to $27.7B), Greater China (-7% to $23.9B), Japan (-5% to $6.8B), and Rest of Asia Pacific (-3% to $9.5B).\"}\n",
-            "{\"guideline\": \"The response should analyze profitability metrics and margins.\", \"prompt\": \"What were Apple's key profitability metrics in Q1 2023?\", \"knowledge\": [\"Gross margin was $50.3 billion or 43.0% of revenue.\", \"Operating income was $36.0 billion.\", \"Net income was $30.0 billion.\", \"Diluted earnings per share was $1.88.\"], \"reference\": \"Apple achieved gross margin of $50.3 billion (43.0% of revenue) in Q1 2023, with operating income of $36.0 billion and net income of $30.0 billion, resulting in diluted earnings per share of $1.88.\"}\n",
-            "{\"guideline\": \"The response should focus on segment margin analysis.\", \"prompt\": \"How did Apple's Products and Services margins compare in Q1 2023?\", \"knowledge\": [\"Products gross margin was 37.0%, down from 38.4%.\", \"Services gross margin was 70.8%, down from 72.4%.\", \"Products gross margin was impacted by foreign exchange.\", \"Services costs increased while leverage improved.\"], \"reference\": \"Apple's Q1 2023 segment margins showed Products gross margin of 37.0% (down from 38.4%) and Services gross margin of 70.8% (down from 72.4%), with Products impacted by foreign exchange while Services saw higher costs offset by improved leverage.\"}\n",
-            "{\"guideline\": \"The response should analyze balance sheet strength and liquidity.\", \"prompt\": \"What was Apple's cash and debt position at the end of Q1 2023?\", \"knowledge\": [\"Cash and marketable securities totaled $165.5 billion.\", \"Total term debt was $109.4 billion.\", \"Commercial paper outstanding was $1.7 billion.\", \"Generated operating cash flow of $34.0 billion in Q1.\"], \"reference\": \"Apple maintained a strong financial position with $165.5 billion in cash and marketable securities against $109.4 billion in term debt and $1.7 billion in commercial paper, while generating $34.0 billion in Q1 operating cash flow.\"}\n",
-            "{\"guideline\": \"The response should focus on key business metrics and operational performance.\", \"prompt\": \"How did Apple's product categories perform in Q1 2023?\", \"knowledge\": [\"iPhone revenue declined 8% to $65.8 billion.\", \"Mac revenue fell 29% to $7.7 billion.\", \"iPad revenue grew 30% to $9.4 billion.\", \"Wearables revenue decreased 8% to $13.5 billion.\", \"Services reached an all-time high of $20.8 billion.\"], \"reference\": \"Apple's Q1 2023 product performance was mixed, with iPhone (-8% to $65.8B), Mac (-29% to $7.7B), and Wearables (-8% to $13.5B) declining, while iPad grew 30% to $9.4B and Services hit a record $20.8B.\"}\n",
-            "{\"guideline\": \"The response should analyze capital return and shareholder value.\", \"prompt\": \"What actions did Apple take to return capital to shareholders in Q1 2023?\", \"knowledge\": [\"Repurchased $19.0 billion of common stock.\", \"Paid $3.8 billion in dividends and equivalents.\", \"Declared dividend of $0.23 per share.\", \"Reduced share count by approximately 133 million shares.\"], \"reference\": \"Apple returned capital to shareholders through $19.0 billion in share repurchases and $3.8 billion in dividends in Q1 2023, with a $0.23 per share dividend and net reduction of approximately 133 million shares outstanding.\"}\n",
-            "{\"guideline\": \"The response should focus on expense management and operational efficiency.\", \"prompt\": \"How did Apple's operating expenses change in Q1 2023?\", \"knowledge\": [\"R&D expenses increased to $7.7 billion from $6.3 billion.\", \"SG&A expenses remained relatively flat at $6.6 billion.\", \"Total operating expenses were $14.3 billion or 12% of revenue.\", \"Headcount-related expenses drove R&D growth.\"], \"reference\": \"Apple's Q1 2023 operating expenses totaled $14.3 billion (12% of revenue), with R&D increasing to $7.7 billion due to higher headcount costs while SG&A remained stable at $6.6 billion.\"}\n",
-            "{\"guideline\": \"The response should analyze working capital and operational metrics.\", \"prompt\": \"How did Apple's working capital metrics change in Q1 2023?\", \"knowledge\": [\"Accounts receivable decreased to $23.8 billion.\", \"Inventories increased to $6.8 billion.\", \"Accounts payable decreased to $57.9 billion.\", \"Vendor non-trade receivables were $30.4 billion.\"], \"reference\": \"Apple's Q1 2023 working capital showed accounts receivable of $23.8 billion, increased inventories of $6.8 billion, accounts payable of $57.9 billion, and vendor non-trade receivables of $30.4 billion.\"}\n",
-            "{\"guideline\": \"The response should focus on tax strategy and effective rates.\", \"prompt\": \"What was Apple's tax position in Q1 2023?\", \"knowledge\": [\"Effective tax rate was 15.8%.\", \"Provision for income taxes was $5.6 billion.\", \"Lower rate driven by foreign earnings differences.\", \"Benefited from R&D credits and share-based compensation.\"], \"reference\": \"Apple's Q1 2023 effective tax rate was 15.8% with a tax provision of $5.6 billion, benefiting from foreign earnings differentials, R&D credits, and tax benefits from share-based compensation.\"}\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "!head data/fin_train.jsonl"
       ]

--- a/06-improve-agent-performance/improvement-overview.ipynb
+++ b/06-improve-agent-performance/improvement-overview.ipynb
@@ -1443,7 +1443,7 @@
       "source": [
         " ### 7.3 Checking the Status.\n",
         "\n",
-        " You can check the status of the job. For detailed information, refer to the API documentation. When the tuning job is complete, the status will turn to completed. The response payload will also contain evaluation_results ."
+        " You can check the status of the job. For detailed information, refer to the API documentation. When the tuning job is complete, the status will turn to completed. The response payload will also contain evaluation_results."
       ]
     },
     {
@@ -1469,11 +1469,19 @@
       "source": [
         "When the tuning job is complete, the metadata would look like the following:\n",
         "```\n",
-        "{'job_status': 'completed',\n",
-        " 'evaluation_results': {'grounded_generation_train_test.json_equivalence': 1.0,\n",
-        "  'grounded_generation_train_test.json_helpfulness': 0.814156498263641,\n",
-        "  'grounded_generation_train_test.json_groundedness': 0.7781168677598632},\n",
-        " 'model_id': 'registry/model-ada3c484-3ce0f31f-llm-fd6c2'}\n",
+        "TuneJobMetadata(job_status='completed',\n",
+        "                evaluation_results=None,\n",
+        "                model_id='registry/tuned-model-101',\n",
+        "                id='e44661f0-bagb-4919-b0df-bada36a31',\n",
+        "                evaluation_metadata={'status': 'completed',\n",
+        "                                     'metrics': {'equivalence_score': {'score': 0.873}},\n",
+        "                                     'job_metadata': {'num_predictions': 200,\n",
+        "                                                      'num_failed_predictions': 0,\n",
+        "                                                      'num_successful_predictions': 200,\n",
+        "                                                      'num_processed_predictions': 0},\n",
+        "                                     'dataset_name': 'eval-results-101',\n",
+        "                                     'model_name': 'registry/tuned-model-101',\n",
+        "                                     'tune_job_id': 'e44661f0-bagb-4919-b0df-bada36a31'})\n",
         " ```"
       ]
     },


### PR DESCRIPTION
This PR involved two changes
- Adding Filter Prompt as a new section for agent improvement
- Adding references to getting usage data (the code is already in the quickstart notebook) -- If there is demand, I can also integrate that existing example with metrics into this notebook