### PR TITLE
feat: Add notebook for vlm ingestion

### DIFF
--- a/01-getting-started/ingest_vlm.ipynb
+++ b/01-getting-started/ingest_vlm.ipynb
@@ -1,0 +1,181 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"https://imagedelivery.net/Dr98IMl5gQ9tPkFM5JRcng/3e5f6fbd-9bc6-4aa1-368e-e8bb1d6ca100/Ultra\" alt=\"Image description\" width=\"160\" />\n",
+    "\n",
+    "<br/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 📚 Ingesting Documents with Visual Documents \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " In this tutorial, we'll walk through how to ingest documents with visual content into Contextual's datastore using the API. The ingestion process will extract text, tables, and visual elements from documents like PDFs, making them searchable and queryable. We'll use the ContextualAI client to handle the ingestion, similar to the standard document ingestion process.\n",
+    "\n",
+    "### Important Links\n",
+    "- [Ingesting documents API References](https://docs.contextual.ai/api-reference/datastores-documents/ingest-document)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json \n",
+    "\n",
+    "API_HOST=\"https://api.app.contextual.ai\"\n",
+    "TOKEN= \"YOUR_API_KEY\"\n",
+    "DATASTORE_NAME=\"DATASTORE_NAME\"\n",
+    "DATASTORE_ID=\"DATASTORE_ID\"\n",
+    "\n",
+    "\n",
+    "headers = {\n",
+    "    \"Authorization\": f\"Bearer {TOKEN}\",\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 🔍 Advanced Document Extraction with Visual Language Models \n",
+    "\n",
+    " Contextual AI supports advanced document extraction using Visual Language Models (VLMs). This enables more sophisticated analysis of visual elements, tables, and layouts in documents, going beyond traditional text-only extraction.\n",
+    "\n",
+    " define the VLM_PROMPT here\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "VLM_PROMPT = \"\"\"\n",
+    "            You are a specialized document chart and figure extractor.\n",
+    "    When given an image of a document page, you accurately extract a chart\n",
+    "\n",
+    "    or figure into text for use in a text based search and retrieval system. A red\n",
+    "    bounding box is drawn around the chart or figure that you have to extract.\n",
+    "\n",
+    "\n",
+    "    Please provide your response in the following format:\n",
+    "\n",
+    "\n",
+    "    **High level description**\n",
+    "\n",
+    "    - Short high level description of the chart or figure, or code snippet in a few sentences, with\n",
+    "    its context in the document.\n",
+    "\n",
+    "    - Describe the title and subtitle of the chart or figure if present.\n",
+    "\n",
+    "    - Describe the x-axis and y-axis labels including scale, range, and units if present.\n",
+    "    Please describe the text in the axes faithfully.\n",
+    "\n",
+    "    - Include description of any legends or annotations present.\n",
+    "\n",
+    "    - If colors indicate different categories or values, describe the color coding.\n",
+    "\n",
+    "    - Extract ALL text content exactly as it appears in the image, maintaining the original formatting.\n",
+    "\n",
+    "    - For code snippets: \n",
+    "        1. First, identify the programming language in the image (Java, Python, etc.)\n",
+    "\n",
+    "        2. Extract the COMPLETE code EXACTLY as it appears, with particular attention to:\n",
+    "            - Preserve ALL indentation (spaces and tabs) precisely as shown\n",
+    "            - Maintain ALL line breaks in their exact positions\n",
+    "            - Keep ALL comments with their original formatting\n",
+    "            - Preserve ALL variable/method names, syntax, and special characters exactly\n",
+    "\n",
+    "        3. Format your response using triple backtick markdown with the language specified:\n",
+    "        ```java\n",
+    "        // Exact code goes here with precise indentation\n",
+    "\n",
+    "    **Key data points**\n",
+    "\n",
+    "    - Extract exact values or data points from the chart or figure that are important\n",
+    "    for search and retrieval.\n",
+    "\n",
+    "    - Include all numerical data present in the chart or figure.\n",
+    "\n",
+    "    - Make sure to relate the data point to the legend or axis labels.\n",
+    "\n",
+    "\n",
+    "    - DO NOT MAKE UP DATA POINTS that are not present in the chart or figure.\n",
+    "    \n",
+    "    When extracting code, prioritize ABSOLUTE ACCURACY over summarization. The goal is to reproduce the code EXACTLY as it appears so it could be copied and used directly. Never abbreviate or summarize code sections.\n",
+    "    **Important**:\n",
+    "    - Accuracy is the priority. Tif there is code in the image, the goal is to produce a copy‑and‑paste‑ready version of the code appearing in the IDE, and all text shown in the figure.\n",
+    "    - Do **not** summarize or omit parts of the code or text. \n",
+    "    - Do **not** add or remove anything.\n",
+    "\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Configure datastore to enable:\n",
+    "1. V2 extraction pipeline - Required for visual content extraction\n",
+    "2. Static captioning with custom prompt - For consistent image descriptions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "datastore_config = {\n",
+    "      \"datastore_type\": \"UNSTRUCTURED\",\n",
+    "      \"name\": DATASTORE_NAME,\n",
+    "      \"configuration\": {\n",
+    "          \"enable_v2_extraction_pipeline\": True,  # Enable V2 pipeline for visual content\n",
+    "          \"extraction\": {\n",
+    "              \"static_captioning_prompt\": VLM_PROMPT  # Custom prompt for image captioning\n",
+    "                  }\n",
+    "          }\n",
+    "}\n",
+    "response = requests.put(f\"{API_HOST}/v1/datastores/{DATASTORE_ID}\", headers=headers, data=json.dumps(datastore_config))\n",
+    "assert response.status_code == 200, response.text\n",
+    "print(response.json())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ctx-shared",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
this PR introduces a new Jupyter notebook tutorial demonstrating how to ingest documents with visual content into Contextual AI datastores using the API and Visual Language Models (VLMs).

## Key Features Demonstrated:
Visual Document Ingestion: Walks users through the process of ingesting documents like PDFs, enabling the extraction of text, tables, and visual elements.

## Advanced VLM Extraction:
- Shows how to configure a datastore to utilize the v2_extraction_pipeline for enhanced visual content analysis.
- Provides an example of a detailed custom VLM_PROMPT designed to extract specific information from charts, figures, and code snippets within documents.
- Illustrates how to update the datastore configuration via the API to enable these features.
- API Usage: Provides practical examples of using the Contextual AI API endpoints for datastore configuration and (implicitly) document ingestion.

This tutorial serves as a guide for users looking to leverage Contextual AI's advanced capabilities for understanding and searching within visually rich documents.